### PR TITLE
add action trigger for event dispatch from other repos

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: 0 0 * * 1 # every Monday at 00:00
+  repository_dispatch:
+    types: component.controlplane.mpas::updated
 
 permissions:
   contents: read # for actions/checkout to fetch code


### PR DESCRIPTION
Will allow other repos in the org to dispatch events to this repo that will trigger the E2E tests.